### PR TITLE
Feat: Make approval counts unique by reviewer

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,32 +7,44 @@ const {
 
 async function main() {
 
-    const owner       = core.getInput('owner');
-    const repo        = core.getInput('repo');
-    const token       = core.getInput('github-token', { required: true });
-    const pull_number = core.getInput('pull_number');
+  const owner = core.getInput('owner');
+  const repo = core.getInput('repo');
+  const token = core.getInput('github-token', { required: true });
+  const pull_number = core.getInput('pull_number');
 
-    const MyOctokit = Octokit.plugin(paginateRest);
-    const octokit = new MyOctokit({ auth: 'token ' + token });
+  const MyOctokit = Octokit.plugin(paginateRest);
+  const octokit = new MyOctokit({ auth: 'token ' + token });
 
-    const result = await octokit.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
-      owner: owner,
-      repo: repo,
-      pull_number: pull_number,
-      per_page: 100
-    });
+  const result = await octokit.paginate('GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews', {
+    owner: owner,
+    repo: repo,
+    pull_number: pull_number,
+    per_page: 100
+  });
 
-    let reviews = {};
+  var last_review_state_by_user = new Map();
 
-    result.forEach(function(v) {
-      reviews[v.state] = (reviews[v.state] || 0) + 1;
-    })
+  result.sort(sortReviewsBySubmittedDate).forEach(function (v) {
+    // As reviews are sorted by ascendant submitted dates, we will have the last review state for each user id in hashmap
+    last_review_state_by_user.set(v.user.id, v.state)
+  });
 
-    core.setOutput('approved', reviews['APPROVED'] || 0);
-    core.setOutput('changes_requested', reviews['CHANGES_REQUESTED'] || 0);
-    core.setOutput('commented', reviews['COMMENTED'] || 0);
-    core.setOutput('pending', reviews['PENDING'] || 0);
-    core.setOutput('dismissed', reviews['DISMISSED'] || 0);
+  console.log([...last_review_state_by_user.entries()]);
+
+  const reviews = [...last_review_state_by_user.values()].reduce((acc, curr) => (acc[curr] = (acc[curr] || 0) + 1, acc), {});
+  console.log(reviews);
+
+  core.setOutput('approved', reviews['APPROVED'] || 0);
+  core.setOutput('changes_requested', reviews['CHANGES_REQUESTED'] || 0);
+  core.setOutput('commented', reviews['COMMENTED'] || 0);
+  core.setOutput('pending', reviews['PENDING'] || 0);
+  core.setOutput('dismissed', reviews['DISMISSED'] || 0);
 }
+
+function sortReviewsBySubmittedDate(a, b) {
+  var dateA = Date.parse(a.submitted_at);
+  var dateB = Date.parse(b.submitted_at);
+  return dateA - dateB;
+};
 
 main().catch(err => core.setFailed(JSON.stringify(err)));


### PR DESCRIPTION
## 🎯 Goal

Do not increment infinite counters : each reviewer have a unique state for a specific PR : 
`APPROVED`, `CHANGES_REQUESTED`, `DISMISSED` or `PENDING`.

To note: `COMMENTED` state is handled differently, because we can add comments without affecting approval states above

## 🚀 What to expect

The sum of all `APPROVED`, `CHANGES_REQUESTED`, `DISMISSED` or `PENDING` states is equal to the number of reviewers. And of course it's the last submitted state for each reviewer.

`COMMENTED` state can be incremented infinitely.

Example with 1 reviewer, who has left 2 simple commented reviews :

![Capture d’écran 2022-06-07 à 18 29 17](https://user-images.githubusercontent.com/22238882/172434657-19add866-f3f8-47e4-8ad0-3b2ab4547ddf.png)
